### PR TITLE
[Core/Custom] Fixed arena 3v3 soloqueue

### DIFF
--- a/src/server/game/Battlegrounds/ArenaTeamMgr.cpp
+++ b/src/server/game/Battlegrounds/ArenaTeamMgr.cpp
@@ -26,6 +26,7 @@
 
 ArenaTeamMgr::ArenaTeamMgr()
 {
+    NextTempArenaTeamId = 0xFFF00000;
     NextArenaTeamId = 1;
 }
 


### PR DESCRIPTION
After getting spammed daily for people wanting me to fix 3v3 solo queue rating, and now every server has the script since I made it public and all these servers don't have rating working (lawl) here's the fix. One simple line.